### PR TITLE
Correct paths for Imba 0.14.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,12 @@ JavaScript source code for the [Imba](https://github.com/somebee/imba) compiler 
 require 'imba/source'
 
 # The Imba runtime:
+Imba::Source.path_for("imba.dev.js")
 Imba::Source.path_for("imba.js")
-Imba::Source.path_for("imba.min.js")
 
 # The Imba compiler:
+Imba::Source.path_for("imbac.dev.js")
 Imba::Source.path_for("imbac.js")
-Imba::Source.path_for("imbac.min.js")
 
 # Path to the directory which contains the files above
 Imba::Source::BROWSER_PATH # => Pathname instance

--- a/imba-source.gemspec
+++ b/imba-source.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
     "README.md",
     "lib/imba/source.rb",
     *Dir.glob("lib/**/*"),
-    *Dir.glob("vendor/imba/lib/browser/imba{,c}*.js")
+    *Dir.glob("vendor/imba/dist/imba{,c}*.js")
   ]
 
   spec.require_paths = ["lib"]

--- a/lib/imba/source.rb
+++ b/lib/imba/source.rb
@@ -4,7 +4,7 @@ require "pathname"
 module Imba
   module Source
     VENDOR_PATH = Pathname.new(__FILE__).expand_path + "../../../vendor/imba"
-    BROWSER_PATH = VENDOR_PATH + "lib/browser"
+    BROWSER_PATH = VENDOR_PATH + "dist"
 
     def self.path_for(name)
       (BROWSER_PATH + name).to_s


### PR DESCRIPTION
In the last version we moved distributions from lib/browser to dist/.
This patch should update this. Not sure how the compilation integrates with Sprockets, so there might be more changes needed?
